### PR TITLE
conda-forge go-feedstock patches 1.12

### DIFF
--- a/misc/cgo/fortran/test.bash
+++ b/misc/cgo/fortran/test.bash
@@ -18,8 +18,7 @@ fi
 
 case "$FC" in
 *gfortran*)
-  libpath=$(dirname $($FC -print-file-name=libgfortran.$libext))
-  export CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath,$libpath -L $libpath"
+  # CONDA's gfortran + go does not need changes to CGO_LDFLAGS
   ;;
 esac
 

--- a/src/cmd/go/go_test.go
+++ b/src/cmd/go/go_test.go
@@ -1580,6 +1580,36 @@ func TestInstallIntoGOBIN(t *testing.T) {
 	tg.wantExecutable("testdata/bin1/go-cmd-test"+exeSuffix, "go install go-cmd-test did not write to testdata/bin1/go-cmd-test")
 }
 
+// Test that without $GOBIN set, binaries get installed
+// into the PREFIX/bin directory when CONDA_BUILD is 1.
+func TestInstallIntoGOBINWithCondaCompiler(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+	tg.setenv("CONDA_GO_COMPILER", "1")
+	tg.setenv("CONDA_BUILD", "")
+	prefix := filepath.Join(tg.pwd(), "testdata", "conda_prefix")
+	tg.creatingTemp(prefix)
+	tg.setenv("CONDA_PREFIX", prefix)
+	tg.setenv("GOPATH", filepath.Join(tg.pwd(), "testdata"))
+	tg.run("install", "go-cmd-test")
+	tg.wantExecutable("testdata/conda_prefix/bin/go-cmd-test"+exeSuffix, "go install go-cmd-test did not write to testdata/conda_prefix/bin/go-cmd-test")
+}
+
+// Test that without $GOBIN set, binaries get installed
+// into the PREFIX/bin directory when CONDA_BUILD is 1.
+func TestInstallIntoGOBINWithCondaBuild(t *testing.T) {
+	tg := testgo(t)
+	defer tg.cleanup()
+	tg.setenv("CONDA_GO_COMPILER", "1")
+	tg.setenv("CONDA_BUILD", "1")
+	prefix := filepath.Join(tg.pwd(), "testdata", "conda_build_prefix")
+	tg.creatingTemp(prefix)
+	tg.setenv("PREFIX", prefix)
+	tg.setenv("SRC_DIR", filepath.Join(tg.pwd(), "testdata"))
+	tg.run("install", "go-cmd-test")
+	tg.wantExecutable("testdata/conda_build_prefix/bin/go-cmd-test"+exeSuffix, "go install go-cmd-test did not write to testdata/conda_build_prefix/bin/go-cmd-test")
+}
+
 // Issue 11065
 func TestInstallToCurrentDirectoryCreatesExecutable(t *testing.T) {
 	tg := testgo(t)

--- a/src/cmd/go/internal/cfg/cfg.go
+++ b/src/cmd/go/internal/cfg/cfg.go
@@ -94,7 +94,7 @@ func init() {
 
 var (
 	GOROOT       = findGOROOT()
-	GOBIN        = os.Getenv("GOBIN")
+	GOBIN        = envOr("GOBIN", defaultCondaGOBIN())
 	GOROOTbin    = filepath.Join(GOROOT, "bin")
 	GOROOTpkg    = filepath.Join(GOROOT, "pkg")
 	GOROOTsrc    = filepath.Join(GOROOT, "src")
@@ -198,3 +198,38 @@ func isGOROOT(path string) bool {
 	}
 	return stat.IsDir()
 }
+
+// defaultCondaGOBIN returns a conda-aware GOBIN path if CONDA_GO_COMPILER
+// is set to 1, otherwise it returns the default empty-string.
+// When CONDA_GO_COMPILER is set to 1, GOBIN's default value is set to:
+//    - $PREFIX/bin if CONDA_BUILD is set to 1 and the PREFIX is set
+//    - $CONDA_PREFIX/bin if CONDA_BUILD is not set to 1 and CONDA_PREFIX is set
+//    - ""  the default value
+func defaultCondaGOBIN() string {
+	if envIsOne("CONDA_GO_COMPILER") {
+		prefixEnv := "CONDA_PREFIX"
+		if envIsOne("CONDA_BUILD") {
+			prefixEnv = "PREFIX"
+		}
+		if prefix, ok := os.LookupEnv(prefixEnv); ok {
+			return filepath.Join(prefix, "bin")
+		}
+	}
+	return ""
+}
+
+func envOr(name, def string) string {
+	s := os.Getenv(name)
+	if s == "" {
+		return def
+	}
+	return s
+}
+
+// envIsOne returns true if environment variable is set to 1, it
+// it returns false otherwise
+func envIsOne(name string) bool {
+	s := os.Getenv(name)
+	return s == "1"
+}
+

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -2373,6 +2373,32 @@ func (b *Builder) gccArchArgs() []string {
 	return nil
 }
 
+// condaGetCompilerFlags returns the value of the given environment variable that is normally available when
+// using conda based compilers, or return the unmodified default no environment variable is found.
+// On linux, it will disable the linker's gc-sections option.
+// On mac/darwin, it will change/reset the macosx minimal version, and set the isysroot if available.
+func condaGetCompilerFlags(key, def string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		switch cfg.Goos {
+		case "linux":
+			if key == "LDFLAGS" {
+				return value + " -Wl,--no-gc-sections"
+			}
+		case "darwin":
+			if key == "CPPFLAGS" {
+				if macosxDefaultTarget, ok := os.LookupEnv("MACOSX_DEFAULT_TARGET"); ok {
+					value = value + " -mmacosx-version-min=" + macosxDefaultTarget
+				}
+				if sysroot, ok := os.LookupEnv("CONDA_BUILD_SYSROOT"); ok {
+					value = value + " -isysroot " + sysroot
+				}
+			}
+		}
+		return value
+	}
+	return def
+}
+
 // envList returns the value of the given environment variable broken
 // into fields, using the default value when the variable is empty.
 func envList(key, def string) []string {
@@ -2410,7 +2436,7 @@ func buildFlags(name, defaults string, fromPackage []string, check func(string, 
 	if err := check(name, "#cgo "+name, fromPackage); err != nil {
 		return nil, err
 	}
-	return str.StringList(envList("CGO_"+name, defaults), fromPackage), nil
+	return str.StringList(envList("CGO_"+name, condaGetCompilerFlags(name, defaults)), fromPackage), nil
 }
 
 var cgoRe = regexp.MustCompile(`[/\\:]`)

--- a/src/cmd/go/script_test.go
+++ b/src/cmd/go/script_test.go
@@ -84,6 +84,12 @@ type backgroundCmd struct {
 
 var extraEnvKeys = []string{
 	"SYSTEMROOT", // must be preserved on Windows to find DLLs; golang.org/issue/25210
+	"CC",
+	"CFLAGS",
+	"CPPFLAGS",
+	"LDFLAGS",
+	"CONDA_BUILD_SYSROOT",
+	"MACOSX_DEPLOYMENT_TARGET",
 }
 
 // setup sets up the test execution temporary directory and environment.

--- a/src/cmd/go/testdata/gopath/src/go-cmd-test/helloworld.go
+++ b/src/cmd/go/testdata/gopath/src/go-cmd-test/helloworld.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("hello world")
+}

--- a/src/go/build/build.go
+++ b/src/go/build/build.go
@@ -262,6 +262,15 @@ func (ctxt *Context) SrcDirs() []string {
 // if set, or else the compiled code's GOARCH, GOOS, and GOROOT.
 var Default Context = defaultContext()
 
+func defaultCondaGOPATH() string {
+	if envIsOne("CONDA_GO_COMPILER") && envIsOne("CONDA_BUILD") {
+		if srcDir := os.Getenv("SRC_DIR"); srcDir != "" {
+			return filepath.Join(srcDir, "gopath")
+		}
+		return defaultGOPATH()
+	}
+	return defaultGOPATH()
+}
 func defaultGOPATH() string {
 	env := "HOME"
 	if runtime.GOOS == "windows" {
@@ -289,7 +298,7 @@ func defaultContext() Context {
 	c.GOARCH = envOr("GOARCH", runtime.GOARCH)
 	c.GOOS = envOr("GOOS", runtime.GOOS)
 	c.GOROOT = pathpkg.Clean(runtime.GOROOT())
-	c.GOPATH = envOr("GOPATH", defaultGOPATH())
+	c.GOPATH = envOr("GOPATH", defaultCondaGOPATH())
 	c.Compiler = runtime.Compiler
 
 	// Each major Go release in the Go 1.x series should add a tag here.
@@ -333,6 +342,13 @@ func envOr(name, def string) string {
 		return def
 	}
 	return s
+}
+
+// envIsOne returns true if environment variable is set to 1, it
+// it returns false otherwise
+func envIsOne(name string) bool {
+	s := os.Getenv(name)
+	return s == "1"
 }
 
 // An ImportMode controls the behavior of the Import method.

--- a/test/fixedbugs/issue10607.go
+++ b/test/fixedbugs/issue10607.go
@@ -1,4 +1,4 @@
-// +build linux,!ppc64
+// +build linux,!ppc64,cgo
 // run
 
 // Copyright 2015 The Go Authors. All rights reserved.


### PR DESCRIPTION
A PR for keeping track of patches present in conda-forge/go-feedstock